### PR TITLE
Typo on local Loom init command

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ yarn gen:extdev-key
 In a new terminal, run:
 
 ```bash
-yarn loom-init
+yarn loom:init
 ```
 
 ### Deploy the smart contract


### PR DESCRIPTION
Fixing typo (`loom:init` vs `loom-init`) on command to initialize the local Loom chain